### PR TITLE
fix indentation in order to improve readability

### DIFF
--- a/e_asin.c
+++ b/e_asin.c
@@ -85,12 +85,13 @@ qS4 =  7.70381505559019352791e-02; /* 0x3FB3B8C5, 0xB12E9282 */
 	} else if (ix<0x3fe00000) {	/* |x|<0.5 */
 	    if(ix<0x3e400000) {		/* if |x| < 2**-27 */
 		if(huge+x>one) return x;/* return x with inexact if x!=0*/
-	    } else 
+	    } else {
 		t = x*x;
-		p = t*(pS0+t*(pS1+t*(pS2+t*(pS3+t*(pS4+t*pS5)))));
-		q = one+t*(qS1+t*(qS2+t*(qS3+t*qS4)));
-		w = p/q;
-		return x+x*w;
+	    }
+	    p = t*(pS0+t*(pS1+t*(pS2+t*(pS3+t*(pS4+t*pS5)))));
+	    q = one+t*(qS1+t*(qS2+t*(qS3+t*qS4)));
+	    w = p/q;
+	    return x+x*w;
 	}
 	/* 1> |x|>= 0.5 */
 	w = one-fabs(x);

--- a/k_rem_pio2.c
+++ b/k_rem_pio2.c
@@ -185,7 +185,8 @@ twon24  =  5.96046447753906250000e-08; /* 0x3E700000, 0x00000000 */
 
     /* compute q[0],q[1],...q[jk] */
 	for (i=0;i<=jk;i++) {
-	    for(j=0,fw=0.0;j<=jx;j++) fw += x[j]*f[jx+i-j]; q[i] = fw;
+	    for(j=0,fw=0.0;j<=jx;j++) fw += x[j]*f[jx+i-j];
+	    q[i] = fw;
 	}
 
 	jz = jk;


### PR DESCRIPTION
Indentation around some conditionals not only had readability issues but also
were breaking builds under the newer gcc compiler. Fix them.

Signed-off-by: Ani Sinha <ani@anisinha.ca>